### PR TITLE
add rollout and env version flags to example input variables

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -89,13 +89,20 @@ output "connection_strings" {
 variable "materialize_instances" {
   description = "List of Materialize instances to be created."
   type = list(object({
-    name            = string
-    namespace       = string
-    database_name   = string
-    cpu_request     = string
-    memory_request  = string
-    memory_limit    = string
-    create_database = optional(bool)
+    name                    = string
+    namespace               = optional(string)
+    database_name           = string
+    create_database         = optional(bool, true)
+    environmentd_version    = optional(string, "v0.130.4")
+    cpu_request             = optional(string, "1")
+    memory_request          = optional(string, "1Gi")
+    memory_limit            = optional(string, "1Gi")
+    in_place_rollout        = optional(bool, false)
+    request_rollout         = optional(string)
+    force_rollout           = optional(string)
+    balancer_memory_request = optional(string, "256Mi")
+    balancer_memory_limit   = optional(string, "256Mi")
+    balancer_cpu_request    = optional(string, "100m")
   }))
   default = []
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -42,6 +42,9 @@ module "materialize" {
 
   install_materialize_operator = true
 
+  operator_version   = var.operator_version
+  orchestratord_version = var.orchestratord_version
+  
   # Once the operator is installed, you can define your Materialize instances here.
   materialize_instances = var.materialize_instances
 }
@@ -84,6 +87,18 @@ output "connection_strings" {
   description = "Connection strings for metadata and persistence backends"
   value       = module.materialize.connection_strings
   sensitive   = true
+}
+
+variable "operator_version" {
+  description = "Version of the Materialize operator to install"
+  type        = string
+  default     = null
+}
+
+variable "orchestratord_version" {
+  description = "Version of the Materialize orchestrator to install"
+  type        = string
+  default     = "v0.130.4"
 }
 
 variable "materialize_instances" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -42,9 +42,9 @@ module "materialize" {
 
   install_materialize_operator = true
 
-  operator_version   = var.operator_version
+  operator_version      = var.operator_version
   orchestratord_version = var.orchestratord_version
-  
+
   # Once the operator is installed, you can define your Materialize instances here.
   materialize_instances = var.materialize_instances
 }

--- a/main.tf
+++ b/main.tf
@@ -123,10 +123,10 @@ locals {
 locals {
   instances = [
     for instance in var.materialize_instances : {
-      name            = instance.name
-      namespace       = instance.namespace
-      database_name   = instance.database_name
-      create_database = instance.create_database
+      name                 = instance.name
+      namespace            = instance.namespace
+      database_name        = instance.database_name
+      create_database      = instance.create_database
       environmentd_version = instance.environmentd_version
 
       metadata_backend_url = format(

--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,7 @@ locals {
       namespace       = instance.namespace
       database_name   = instance.database_name
       create_database = instance.create_database
+      environmentd_version = instance.environmentd_version
 
       metadata_backend_url = format(
         "postgres://%s:%s@%s:5432/%s?sslmode=disable",

--- a/variables.tf
+++ b/variables.tf
@@ -109,17 +109,20 @@ variable "orchestratord_version" {
 variable "materialize_instances" {
   description = "Configuration for Materialize instances"
   type = list(object({
-    name                 = string
-    namespace            = optional(string)
-    database_name        = string
-    create_database      = optional(bool, true)
-    environmentd_version = optional(string, "v0.130.4")
-    cpu_request          = optional(string, "1")
-    memory_request       = optional(string, "1Gi")
-    memory_limit         = optional(string, "1Gi")
-    in_place_rollout     = optional(bool, false)
-    request_rollout      = optional(string)
-    force_rollout        = optional(string)
+    name                    = string
+    namespace               = optional(string)
+    database_name           = string
+    create_database         = optional(bool, true)
+    environmentd_version    = optional(string, "v0.130.4")
+    cpu_request             = optional(string, "1")
+    memory_request          = optional(string, "1Gi")
+    memory_limit            = optional(string, "1Gi")
+    in_place_rollout        = optional(bool, false)
+    request_rollout         = optional(string)
+    force_rollout           = optional(string)
+    balancer_memory_request = optional(string, "256Mi")
+    balancer_memory_limit   = optional(string, "256Mi")
+    balancer_cpu_request    = optional(string, "100m")
   }))
   default = []
 


### PR DESCRIPTION
Add balancerd resource requirements

blocked by: https://github.com/MaterializeInc/terraform-helm-materialize/pull/21

The simple example didn't have rollout args in the input variable... this seems broken so I added them.