### PR TITLE
Use explicit region variable instead of data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ The module has been tested with:
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.25.0 |
+No providers.
 
 ## Modules
 
@@ -44,9 +42,7 @@ The module has been tested with:
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+No resources.
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ locals {
       }
       cloudProvider = {
         type   = "gcp"
-        region = data.google_client_config.current.region
+        region = var.region
         providers = {
           gcp = {
             enabled = true
@@ -166,5 +166,3 @@ locals {
     }
   ]
 }
-
-data "google_client_config" "current" {}


### PR DESCRIPTION
Replacing `data.google_client_config.current.region` with `var.region` in the `helm_values` to fix empty region issue in multi-region GCP projects.



