### PR TITLE
Add forward compatibility disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ This module sets up:
 - Required networking and security configurations
 - Service accounts with proper IAM permissions
 
-> **Warning** This is provided on a best-effort basis and Materialize cannot offer support for this module.
+> [!WARNING]
+> This module is provided on a best-effort basis and Materialize cannot offer support for it.
+>
+> It is not guaranteed to be forward-compatible and may include breaking changes in future versions.
+>
+> The module is intended for demonstration and evaluation purposes only, not for production use.
+>
+> Instead, consider forking this repository as a starting point for building your own production infrastructure.
 
 The module has been tested with:
 - GKE version 1.28

--- a/docs/header.md
+++ b/docs/header.md
@@ -9,7 +9,14 @@ This module sets up:
 - Required networking and security configurations
 - Service accounts with proper IAM permissions
 
-> **Warning** This is provided on a best-effort basis and Materialize cannot offer support for this module.
+> [!WARNING]
+> This module is provided on a best-effort basis and Materialize cannot offer support for it.
+>
+> It is not guaranteed to be forward-compatible and may include breaking changes in future versions.
+>
+> The module is intended for demonstration and evaluation purposes only, not for production use.
+>
+> Instead, consider forking this repository as a starting point for building your own production infrastructure.
 
 The module has been tested with:
 - GKE version 1.28


### PR DESCRIPTION
Similar to what we have in the official [docs](https://materialize.com/docs/self-managed/v25.1/installation/install-on-aws/), adding a small compatibility disclaimer.