### PR TITLE
Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_certificates"></a> [certificates](#module\_certificates) | ./modules/certificates | n/a |
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
 | <a name="module_gke"></a> [gke](#module\_gke) | ./modules/gke | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
-| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.8 |
+| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.9 |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |
 
 ## Resources
@@ -55,10 +56,12 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cert_manager_namespace"></a> [cert\_manager\_namespace](#input\_cert\_manager\_namespace) | The name of the namespace in which cert-manager is or will be installed. | `string` | `"cert-manager"` | no |
 | <a name="input_database_config"></a> [database\_config](#input\_database\_config) | Cloud SQL configuration | <pre>object({<br/>    tier     = optional(string, "db-custom-2-4096")<br/>    version  = optional(string, "POSTGRES_15")<br/>    password = string<br/>    username = optional(string, "materialize")<br/>    db_name  = optional(string, "materialize")<br/>  })</pre> | n/a | yes |
 | <a name="input_gke_config"></a> [gke\_config](#input\_gke\_config) | GKE cluster configuration. Make sure to use large enough machine types for your Materialize instances. | <pre>object({<br/>    node_count   = number<br/>    machine_type = string<br/>    disk_size_gb = number<br/>    min_nodes    = number<br/>    max_nodes    = number<br/>  })</pre> | <pre>{<br/>  "disk_size_gb": 50,<br/>  "machine_type": "e2-standard-4",<br/>  "max_nodes": 2,<br/>  "min_nodes": 1,<br/>  "node_count": 1<br/>}</pre> | no |
 | <a name="input_helm_chart"></a> [helm\_chart](#input\_helm\_chart) | Chart name from repository or local path to chart. For local charts, set the path to the chart directory. | `string` | `"materialize-operator"` | no |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Values to pass to the Helm chart | `any` | `{}` | no |
+| <a name="input_install_cert_manager"></a> [install\_cert\_manager](#input\_install\_cert\_manager) | Whether to install cert-manager. | `bool` | `false` | no |
 | <a name="input_install_materialize_operator"></a> [install\_materialize\_operator](#input\_install\_materialize\_operator) | Whether to install the Materialize operator | `bool` | `true` | no |
 | <a name="input_install_metrics_server"></a> [install\_metrics\_server](#input\_install\_metrics\_server) | Whether to install the metrics-server for the Materialize Console. Defaults to false since GKE installs one by default in the kube-system namespace. Only set to true if the GKE cluster was deployed with [monitoring explicitly turned off](https://cloud.google.com/kubernetes-engine/docs/how-to/configure-metrics#:~:text=To%20disable%20system%20metric%20collection,for%20the%20%2D%2Dmonitoring%20flag). Refer to the [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/configure-metrics#:~:text=To%20disable%20system%20metric%20collection,for%20the%20%2D%2Dmonitoring%20flag) for more information, including impact to GKE customer support efforts. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all resources | `map(string)` | `{}` | no |
@@ -67,11 +70,12 @@ No resources.
 | <a name="input_network_config"></a> [network\_config](#input\_network\_config) | Network configuration for the GKE cluster | <pre>object({<br/>    subnet_cidr   = string<br/>    pods_cidr     = string<br/>    services_cidr = string<br/>  })</pre> | n/a | yes |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
 | <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `null` | no |
-| <a name="input_orchestratord_version"></a> [orchestratord\_version](#input\_orchestratord\_version) | Version of the Materialize orchestrator to install | `string` | `"v0.130.4"` | no |
+| <a name="input_orchestratord_version"></a> [orchestratord\_version](#input\_orchestratord\_version) | Version of the Materialize orchestrator to install | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to be used for resource names | `string` | `"materialize"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where resources will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region where resources will be created | `string` | `"us-central1"` | no |
 | <a name="input_use_local_chart"></a> [use\_local\_chart](#input\_use\_local\_chart) | Whether to use a local chart instead of one from a repository | `bool` | `false` | no |
+| <a name="input_use_self_signed_cluster_issuer"></a> [use\_self\_signed\_cluster\_issuer](#input\_use\_self\_signed\_cluster\_issuer) | Whether to install and use a self-signed ClusterIssuer for TLS. Due to limitations in Terraform, this may not be enabled before the cert-manager CRDs are installed. | `bool` | `false` | no |
 
 ## Outputs
 
@@ -84,4 +88,26 @@ No resources.
 | <a name="output_operator"></a> [operator](#output\_operator) | Materialize operator details |
 | <a name="output_service_accounts"></a> [service\_accounts](#output\_service\_accounts) | Service account details |
 | <a name="output_storage"></a> [storage](#output\_storage) | GCS bucket details |
+
+## Connecting to Materialize instances
+
+Access to the database is through the balancerd pods on:
+* Port 6875 for SQL connections.
+* Port 6876 for HTTP(S) connections.
+
+Access to the web console is through the console pods on port 8080.
+
+#### TLS support
+
+For example purposes, optional TLS support is provided by using `cert-manager` and a self-signed `ClusterIssuer`.
+
+More advanced TLS support using user-provided CAs or per-Materialize `Issuer`s are out of scope for this Terraform module. Please refer to the [cert-manager documentation](https://cert-manager.io/docs/configuration/) for detailed guidance on more advanced usage.
+
+###### To enable installation of `cert-manager` and configuration of the self-signed `ClusterIssuer`
+1. Set `install_cert_manager` to `true`.
+1. Run `terraform apply`.
+1. Set `use_self_signed_cluster_issuer` to `true`.
+1. Run `terraform apply`.
+
+Due to limitations in Terraform, it cannot plan Kubernetes resources using CRDs that do not exist yet. We need to first install `cert-manager` in the first `terraform apply`, before defining any `ClusterIssuer` or `Certificate` resources which get created in the second `terraform apply`.
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cert_manager_chart_version"></a> [cert\_manager\_chart\_version](#input\_cert\_manager\_chart\_version) | Version of the cert-manager helm chart to install. | `string` | `"v1.17.1"` | no |
+| <a name="input_cert_manager_install_timeout"></a> [cert\_manager\_install\_timeout](#input\_cert\_manager\_install\_timeout) | Timeout for installing the cert-manager helm chart, in seconds. | `number` | `300` | no |
 | <a name="input_cert_manager_namespace"></a> [cert\_manager\_namespace](#input\_cert\_manager\_namespace) | The name of the namespace in which cert-manager is or will be installed. | `string` | `"cert-manager"` | no |
 | <a name="input_database_config"></a> [database\_config](#input\_database\_config) | Cloud SQL configuration | <pre>object({<br/>    tier     = optional(string, "db-custom-2-4096")<br/>    version  = optional(string, "POSTGRES_15")<br/>    password = string<br/>    username = optional(string, "materialize")<br/>    db_name  = optional(string, "materialize")<br/>  })</pre> | n/a | yes |
 | <a name="input_gke_config"></a> [gke\_config](#input\_gke\_config) | GKE cluster configuration. Make sure to use large enough machine types for your Materialize instances. | <pre>object({<br/>    node_count   = number<br/>    machine_type = string<br/>    disk_size_gb = number<br/>    min_nodes    = number<br/>    max_nodes    = number<br/>  })</pre> | <pre>{<br/>  "disk_size_gb": 50,<br/>  "machine_type": "e2-standard-4",<br/>  "max_nodes": 2,<br/>  "min_nodes": 1,<br/>  "node_count": 1<br/>}</pre> | no |

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -1,0 +1,21 @@
+## Connecting to Materialize instances
+
+Access to the database is through the balancerd pods on:
+* Port 6875 for SQL connections.
+* Port 6876 for HTTP(S) connections.
+
+Access to the web console is through the console pods on port 8080.
+
+#### TLS support
+
+For example purposes, optional TLS support is provided by using `cert-manager` and a self-signed `ClusterIssuer`.
+
+More advanced TLS support using user-provided CAs or per-Materialize `Issuer`s are out of scope for this Terraform module. Please refer to the [cert-manager documentation](https://cert-manager.io/docs/configuration/) for detailed guidance on more advanced usage.
+
+###### To enable installation of `cert-manager` and configuration of the self-signed `ClusterIssuer`
+1. Set `install_cert_manager` to `true`.
+1. Run `terraform apply`.
+1. Set `use_self_signed_cluster_issuer` to `true`.
+1. Run `terraform apply`.
+
+Due to limitations in Terraform, it cannot plan Kubernetes resources using CRDs that do not exist yet. We need to first install `cert-manager` in the first `terraform apply`, before defining any `ClusterIssuer` or `Certificate` resources which get created in the second `terraform apply`.

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -141,7 +141,7 @@ output "network" {
 variable "orchestratord_version" {
   description = "Version of the Materialize orchestrator to install"
   type        = string
-  default     = "v0.130.4"
+  default     = null
 }
 
 variable "materialize_instances" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -72,9 +72,11 @@ module "materialize" {
   }
 
   install_materialize_operator = true
+  operator_version             = var.operator_version
+  orchestratord_version        = var.orchestratord_version
 
-  operator_version      = var.operator_version
-  orchestratord_version = var.orchestratord_version
+  install_cert_manager           = var.install_cert_manager
+  use_self_signed_cluster_issuer = var.use_self_signed_cluster_issuer
 
   # Once the operator is installed, you can define your Materialize instances here.
   materialize_instances = var.materialize_instances
@@ -161,4 +163,16 @@ variable "materialize_instances" {
     balancer_cpu_request    = optional(string, "100m")
   }))
   default = []
+}
+
+variable "install_cert_manager" {
+  description = "Whether to install cert-manager."
+  type        = bool
+  default     = false
+}
+
+variable "use_self_signed_cluster_issuer" {
+  description = "Whether to install and use a self-signed ClusterIssuer for TLS. Due to limitations in Terraform, this may not be enabled before the cert-manager CRDs are installed."
+  type        = bool
+  default     = false
 }

--- a/main.tf
+++ b/main.tf
@@ -125,9 +125,9 @@ locals {
       }
     }
     operator = {
-      image = {
+      image = var.orchestratord_version == null ? {} : {
         tag = var.orchestratord_version
-      }
+      },
       cloudProvider = {
         type   = "gcp"
         region = var.region

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,8 @@ module "certificates" {
   source = "./modules/certificates"
 
   install_cert_manager           = var.install_cert_manager
+  cert_manager_install_timeout   = var.cert_manager_install_timeout
+  cert_manager_chart_version     = var.cert_manager_chart_version
   use_self_signed_cluster_issuer = var.use_self_signed_cluster_issuer
   cert_manager_namespace         = var.cert_manager_namespace
   name_prefix                    = var.prefix

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ module "certificates" {
 }
 
 module "operator" {
-  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.8"
+  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.9"
 
   count = var.install_materialize_operator ? 1 : 0
 

--- a/modules/certificates/main.tf
+++ b/modules/certificates/main.tf
@@ -1,0 +1,104 @@
+resource "kubernetes_namespace" "cert_manager" {
+  count = var.install_cert_manager ? 1 : 0
+
+  metadata {
+    name = var.cert_manager_namespace
+  }
+}
+
+resource "helm_release" "cert_manager" {
+  count = var.install_cert_manager ? 1 : 0
+
+  # cert-manager is a singleton resource for the cluster,
+  # so not using name prefixes here.
+  name       = "cert-manager"
+  namespace  = kubernetes_namespace.cert_manager[0].metadata[0].name
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  version    = "v1.17.1"
+
+  set {
+    name  = "crds.enabled"
+    value = "true"
+  }
+
+  depends_on = [
+    kubernetes_namespace.cert_manager,
+  ]
+}
+
+resource "kubernetes_manifest" "self_signed_cluster_issuer" {
+  # only create these after cert manager is installed
+  count = var.use_self_signed_cluster_issuer ? 1 : 0
+
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "ClusterIssuer"
+    "metadata" = {
+      "name" = "${var.name_prefix}-self-signed"
+    }
+    "spec" = {
+      "selfSigned" = {}
+    }
+  }
+
+  depends_on = [
+    helm_release.cert_manager,
+  ]
+}
+
+resource "kubernetes_manifest" "self_signed_root_ca_certificate" {
+  count = var.use_self_signed_cluster_issuer ? 1 : 0
+
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = "${var.name_prefix}-self-signed-ca"
+      "namespace" = var.cert_manager_namespace
+    }
+    "spec" = {
+      "isCA"       = true
+      "commonName" = "${var.name_prefix}-self-signed-ca"
+      "secretName" = "${var.name_prefix}-root-ca"
+      "privateKey" = {
+        "algorithm"      = "RSA"
+        "encoding"       = "PKCS8"
+        "size"           = 4096
+        "rotationPolicy" = "Always"
+      }
+      "issuerRef" = {
+        "name"  = "${var.name_prefix}-self-signed"
+        "kind"  = "ClusterIssuer"
+        "group" = "cert-manager.io"
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.cert_manager,
+    kubernetes_manifest.self_signed_cluster_issuer,
+  ]
+}
+
+resource "kubernetes_manifest" "root_ca_cluster_issuer" {
+  count = var.use_self_signed_cluster_issuer ? 1 : 0
+
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "ClusterIssuer"
+    "metadata" = {
+      "name" = "${var.name_prefix}-root-ca"
+    }
+    "spec" = {
+      "ca" = {
+        "secretName" = "${var.name_prefix}-root-ca"
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.cert_manager,
+    kubernetes_manifest.self_signed_root_ca_certificate,
+  ]
+}

--- a/modules/certificates/main.tf
+++ b/modules/certificates/main.tf
@@ -15,7 +15,8 @@ resource "helm_release" "cert_manager" {
   namespace  = kubernetes_namespace.cert_manager[0].metadata[0].name
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.17.1"
+  version    = var.cert_manager_chart_version
+  timeout    = var.cert_manager_install_timeout
 
   set {
     name  = "crds.enabled"

--- a/modules/certificates/outputs.tf
+++ b/modules/certificates/outputs.tf
@@ -1,0 +1,4 @@
+output "cluster_issuer_name" {
+  description = "Name of the ClusterIssuer"
+  value       = var.use_self_signed_cluster_issuer ? kubernetes_manifest.root_ca_cluster_issuer[0].object.metadata.name : null
+}

--- a/modules/certificates/variables.tf
+++ b/modules/certificates/variables.tf
@@ -17,3 +17,13 @@ variable "name_prefix" {
   description = "The name prefix to use for Kubernetes resources. Does not apply to cert-manager itself, as that is a singleton per cluster."
   type        = string
 }
+
+variable "cert_manager_install_timeout" {
+  description = "Timeout for installing the cert-manager helm chart, in seconds."
+  type        = number
+}
+
+variable "cert_manager_chart_version" {
+  description = "Version of the cert-manager helm chart to install."
+  type        = string
+}

--- a/modules/certificates/variables.tf
+++ b/modules/certificates/variables.tf
@@ -1,0 +1,19 @@
+variable "install_cert_manager" {
+  description = "Whether to install cert-manager."
+  type        = bool
+}
+
+variable "use_self_signed_cluster_issuer" {
+  description = "Whether to install and use a self-signed ClusterIssuer for TLS. Due to limitations in Terraform, this may not be enabled before the cert-manager CRDs are installed."
+  type        = bool
+}
+
+variable "cert_manager_namespace" {
+  description = "The name of the namespace in which cert-manager is or will be installed."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "The name prefix to use for Kubernetes resources. Does not apply to cert-manager itself, as that is a singleton per cluster."
+  type        = string
+}

--- a/modules/certificates/versions.tf
+++ b/modules/certificates/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "helm_values" {
 variable "orchestratord_version" {
   description = "Version of the Materialize orchestrator to install"
   type        = string
-  default     = "v0.130.4"
+  default     = null
 }
 
 variable "materialize_instances" {

--- a/variables.tf
+++ b/variables.tf
@@ -175,3 +175,15 @@ variable "cert_manager_namespace" {
   type        = string
   default     = "cert-manager"
 }
+
+variable "cert_manager_install_timeout" {
+  description = "Timeout for installing the cert-manager helm chart, in seconds."
+  type        = number
+  default     = 300
+}
+
+variable "cert_manager_chart_version" {
+  description = "Version of the cert-manager helm chart to install."
+  type        = string
+  default     = "v1.17.1"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -157,3 +157,21 @@ variable "install_metrics_server" {
   type        = bool
   default     = false
 }
+
+variable "install_cert_manager" {
+  description = "Whether to install cert-manager."
+  type        = bool
+  default     = false
+}
+
+variable "use_self_signed_cluster_issuer" {
+  description = "Whether to install and use a self-signed ClusterIssuer for TLS. Due to limitations in Terraform, this may not be enabled before the cert-manager CRDs are installed."
+  type        = bool
+  default     = false
+}
+
+variable "cert_manager_namespace" {
+  description = "The name of the namespace in which cert-manager is or will be installed."
+  type        = string
+  default     = "cert-manager"
+}


### PR DESCRIPTION
Support installing cert-manager and using a ClusterIssuer for TLS.

Also updated terraform-helm-materialize module to v0.1.9 and remove unnecessary orchestratord version overrides to pick up a fix for the certificate mount permissions in the console pod.