### PR TITLE
Bump for terraform-helm-materialize v0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This module sets up:
 The module has been tested with:
 - GKE version 1.28
 - PostgreSQL 15
-- Materialize Operator v0.1.0
+- terraform-helm-materialize v0.1.12 (Materialize Operator v25.1.7)
 
 ## Requirements
 
@@ -44,7 +44,7 @@ No providers.
 | <a name="module_gke"></a> [gke](#module\_gke) | ./modules/gke | n/a |
 | <a name="module_load_balancers"></a> [load\_balancers](#module\_load\_balancers) | ./modules/load_balancers | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
-| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.11 |
+| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.12 |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |
 
 ## Resources

--- a/docs/header.md
+++ b/docs/header.md
@@ -19,4 +19,4 @@ This module sets up:
 The module has been tested with:
 - GKE version 1.28
 - PostgreSQL 15
-- Materialize Operator v0.1.0
+- terraform-helm-materialize v0.1.12 (Materialize Operator v25.1.7)

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ module "certificates" {
 }
 
 module "operator" {
-  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.11"
+  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.12"
 
   count = var.install_materialize_operator ? 1 : 0
 


### PR DESCRIPTION
Verified via `terraform describe`:

- ` Pulling image "materialize/orchestratord:v0.138.0"`
- `Successfully pulled image "materialize/environmentd:v0.130.8" in 8.057s`

And via console:
<img width="572" alt="Screenshot 2025-04-08 at 3 38 35 PM" src="https://github.com/user-attachments/assets/8831e552-a57d-47d8-81af-2063d74bd3d0" />
