### PR TITLE
Bump ephemeral-storage-setup-image to v0.3.4

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -230,5 +230,5 @@ variable "disk_support_config" {
 variable "disk_setup_image" {
   description = "Docker image for the disk setup script"
   type        = string
-  default     = "materialize/ephemeral-storage-setup-image:v0.3.3"
+  default     = "materialize/ephemeral-storage-setup-image:v0.3.4"
 }


### PR DESCRIPTION
Bump ephemeral-storage-setup-image to v0.3.4, which contains better logging.