### PR TITLE
Add pointer to materialize-terraform-self-managed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
+> [!NOTE]
+> A newer module is available at [materialize-terraform-self-managed](https://github.com/MaterializeInc/materialize-terraform-self-managed). It takes a more modular approach so you can pick the pieces you need. If you would like to move over, the [GCP migration example](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/gcp/examples/migration) is a good starting point.
+
 # Materialize on Google Cloud Platform
 
 Terraform module for deploying Materialize on Google Cloud Platform (GCP) with all required infrastructure components.

--- a/docs/header.md
+++ b/docs/header.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> A newer module is available at [materialize-terraform-self-managed](https://github.com/MaterializeInc/materialize-terraform-self-managed). It takes a more modular approach so you can pick the pieces you need. If you would like to move over, the [GCP migration example](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/gcp/examples/migration) is a good starting point.
+
 # Materialize on Google Cloud Platform
 
 Terraform module for deploying Materialize on Google Cloud Platform (GCP) with all required infrastructure components.


### PR DESCRIPTION
Adds a short note at the top of the README letting users know about the newer [materialize-terraform-self-managed](https://github.com/MaterializeInc/materialize-terraform-self-managed) module and where to find the GCP migration example.

Fixes https://linear.app/materializeinc/issue/DEP-88/materialize-docs-pointing-to-migration-guides

